### PR TITLE
adding filters option

### DIFF
--- a/tasks/swig_compile.js
+++ b/tasks/swig_compile.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var swig = require('swig');
+var path = require('path');
 
 module.exports = function(grunt) {
 
@@ -26,6 +27,12 @@ module.exports = function(grunt) {
 			locals: {}
 		});
 
+        if (options['filters']) {
+            var filters = require(path.resolve(options['filters']));
+            Object.keys(filters).forEach(function (name) {
+                swig.setFilter(name, filters[name]);
+            });
+        }
 		// Iterate over all specified file groups.
 		this.files.forEach(function(f) {
 			// Concat specified files.


### PR DESCRIPTION
This change would allow templates with custom filters to be compiled using a new option `filters` which would accept a string with a file path.
